### PR TITLE
tags: sanitize tag keys

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -260,6 +260,9 @@ func protoLabelValuesToLabelValues(rubricLabelKeys []*metricspb.LabelKey, protoL
 	}
 	plainLabelValues := make([]string, len(rubricLabelKeys))
 	for i := 0; i < len(rubricLabelKeys); i++ {
+		if i >= len(protoLabelValues) {
+			continue
+		}
 		protoLabelValue := protoLabelValues[i]
 		if protoLabelValue.Value != "" || protoLabelValue.HasValue {
 			plainLabelValues[i] = protoLabelValue.Value
@@ -271,7 +274,8 @@ func protoLabelValuesToLabelValues(rubricLabelKeys []*metricspb.LabelKey, protoL
 func protoLabelKeysToLabels(protoLabelKeys []*metricspb.LabelKey) []string {
 	labelKeys := make([]string, 0, len(protoLabelKeys))
 	for _, protoLabelKey := range protoLabelKeys {
-		labelKeys = append(labelKeys, protoLabelKey.GetKey())
+		sanitizedKey := sanitize(protoLabelKey.GetKey())
+		labelKeys = append(labelKeys, sanitizedKey)
 	}
 	return labelKeys
 }

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -306,6 +306,7 @@ func makeMetrics() []*metricspb.Metric {
 					LabelKeys: []*metricspb.LabelKey{
 						{Key: "os", Description: "Operating system"},
 						{Key: "arch", Description: "Architecture"},
+						{Key: "my.org/department", Description: "The department that owns this server"},
 					},
 				},
 			},
@@ -315,6 +316,7 @@ func makeMetrics() []*metricspb.Metric {
 					LabelValues: []*metricspb.LabelValue{
 						{Value: "windows"},
 						{Value: "x86"},
+						{Value: "Storage"},
 					},
 					Points: []*metricspb.Point{
 						{
@@ -330,6 +332,7 @@ func makeMetrics() []*metricspb.Metric {
 					LabelValues: []*metricspb.LabelValue{
 						{Value: "darwin"},
 						{Value: "386"},
+						{Value: "Ops"},
 					},
 					Points: []*metricspb.Point{
 						{
@@ -396,8 +399,8 @@ func TestMetricsEndpointOutput(t *testing.T) {
 
 	want := `# HELP this_one_there_where_ Extra ones
 # TYPE this_one_there_where_ counter
-this_one_there_where_{arch="386",os="darwin"} 49.5
-this_one_there_where_{arch="x86",os="windows"} 99
+this_one_there_where_{arch="386",my_org_department="Ops",os="darwin"} 49.5
+this_one_there_where_{arch="x86",my_org_department="Storage",os="windows"} 99
 # HELP with_metric_descriptor This is a test
 # TYPE with_metric_descriptor histogram
 with_metric_descriptor_bucket{le="0"} 0


### PR DESCRIPTION
Ensure that we sanitize tag keys before
exporting them. This now brings tag-key serialization
parity with the OpenCensus Prometheus stats exporter.

This issue was discovered when examining an error that
a consuming project (OpenCensus PHP stats daemon) was
encountering.

Fixes #1