### PR TITLE
sanitize: remove 100 byte key-length limit from OpenCensus

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -62,15 +62,13 @@ var (
 )
 
 var metric1 = &metricspb.Metric{
-	Descriptor_: &metricspb.Metric_MetricDescriptor{
-		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name:        "this/one/there(where)",
-			Description: "Extra ones",
-			Unit:        "1",
-			LabelKeys: []*metricspb.LabelKey{
-				{Key: "os", Description: "Operating system"},
-				{Key: "arch", Description: "Architecture"},
-			},
+	MetricDescriptor: &metricspb.MetricDescriptor{
+		Name:        "this/one/there(where)",
+		Description: "Extra ones",
+		Unit:        "1",
+		LabelKeys: []*metricspb.LabelKey{
+			{Key: "os", Description: "Operating system"},
+			{Key: "arch", Description: "Architecture"},
 		},
 	},
 	Timeseries: []*metricspb.TimeSeries{

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -186,12 +186,10 @@ func TestCollectNonRacy(t *testing.T) {
 					},
 				},
 				{
-					Descriptor_: &metricspb.Metric_MetricDescriptor{
-						MetricDescriptor: &metricspb.MetricDescriptor{
-							Name:        "counter",
-							Description: "This is a counter",
-							Unit:        "1",
-						},
+					MetricDescriptor: &metricspb.MetricDescriptor{
+						Name:        "counter",
+						Description: "This is a counter",
+						Unit:        "1",
 					},
 					Timeseries: []*metricspb.TimeSeries{
 						{
@@ -290,16 +288,14 @@ func makeMetrics() []*metricspb.Metric {
 			},
 		},
 		{
-			Descriptor_: &metricspb.Metric_MetricDescriptor{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "this/one/there(where)",
-					Description: "Extra ones",
-					Unit:        "1",
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "os", Description: "Operating system"},
-						{Key: "arch", Description: "Architecture"},
-						{Key: "my.org/department", Description: "The department that owns this server"},
-					},
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        "this/one/there(where)",
+				Description: "Extra ones",
+				Unit:        "1",
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "os", Description: "Operating system"},
+					{Key: "arch", Description: "Architecture"},
+					{Key: "my.org/department", Description: "The department that owns this server"},
 				},
 			},
 			Timeseries: []*metricspb.TimeSeries{
@@ -331,6 +327,38 @@ func makeMetrics() []*metricspb.Metric {
 							Timestamp: endTimestamp,
 							Value: &metricspb.Point_DoubleValue{
 								DoubleValue: 49.5,
+							},
+						},
+					},
+				},
+			},
+		},
+		// Unlimited key length.
+		{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        strings.Repeat("a_", 60),
+				Description: "Unlimited metric key lengths",
+				Unit:        "1",
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "os", Description: "Operating system"},
+					{Key: "arch", Description: "Architecture"},
+					{Key: "my.org/department", Description: "The department that owns this server"},
+					{Key: strings.Repeat("key", 50), Description: "The department that owns this server"},
+				},
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					StartTimestamp: startTimestamp,
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "windows"},
+						{Value: "x86"},
+						{Value: "Storage"},
+					},
+					Points: []*metricspb.Point{
+						{
+							Timestamp: endTimestamp,
+							Value: &metricspb.Point_Int64Value{
+								Int64Value: 99,
 							},
 						},
 					},
@@ -389,7 +417,10 @@ func TestMetricsEndpointOutput(t *testing.T) {
 		t.Fatalf("error reported by Prometheus registry:\n\t%s", output)
 	}
 
-	want := `# HELP this_one_there_where_ Extra ones
+	want := `# HELP a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_ Unlimited metric key lengths
+# TYPE a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_ counter
+a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_{arch="x86",keykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykeykey="",my_org_department="Storage",os="windows"} 99
+# HELP this_one_there_where_ Extra ones
 # TYPE this_one_there_where_ counter
 this_one_there_where_{arch="386",my_org_department="Ops",os="darwin"} 49.5
 this_one_there_where_{arch="x86",my_org_department="Storage",os="windows"} 99

--- a/sanitize.go
+++ b/sanitize.go
@@ -14,7 +14,7 @@
 
 package prometheus
 
-// The code for sanitize is copied verbatim from:
+// The code for sanitize is mostly copied from:
 //  https://github.com/census-instrumentation/opencensus-go/blob/950a67f393d867cfbe91414063b69e511f42fefb/internal/sanitize.go#L1-L50
 
 import (
@@ -22,17 +22,16 @@ import (
 	"unicode"
 )
 
-const labelKeySizeLimit = 100
-
-// sanitize returns a string that is trunacated to 100 characters if it's too
-// long, and replaces non-alphanumeric characters to underscores.
+// sanitize replaces non-alphanumeric characters with underscores in s.
 func sanitize(s string) string {
 	if len(s) == 0 {
 		return s
 	}
-	if len(s) > labelKeySizeLimit {
-		s = s[:labelKeySizeLimit]
-	}
+
+        // Note: No length limit for label keys because Prometheus doesn't
+        // define a length limit, thus we should NOT be truncating label keys.
+        // See https://github.com/orijtech/prometheus-go-metrics-exporter/issues/4.
+	
 	s = strings.Map(sanitizeRune, s)
 	if unicode.IsDigit(rune(s[0])) {
 		s = "key_" + s


### PR DESCRIPTION
Removes the seemingly arbitrary 100 byte key-length that
we pulled years ago from OpenCensus Go's sanitize function
verbatim. Contextually those key length limits make sense for
Stackdriver, but Prometheus doesn't mention the need for limiting
key lengths (at least that I know of).

Fixes #4