### PR TITLE
Continue on error by default

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -60,7 +60,7 @@ func New(o Options) (*Exporter, error) {
 		options:   o,
 		gatherer:  o.Registry,
 		collector: collector,
-		handler:   promhttp.HandlerFor(o.Registry, promhttp.HandlerOpts{}),
+		handler:   promhttp.HandlerFor(o.Registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}),
 	}
 	return exp, nil
 }


### PR DESCRIPTION
Erroring when able to continue is brittle and was causing the following `HELP` mismatch on the same metric name to break metric collection merge for us.

```
# HELP process_start_time_seconds Start time of the process since unix epoch.

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
```

When trying to get merged result from the exporter:

```
An error has occurred while serving metrics:

collected metric process_start_time_seconds label:<name:"cluster" value:"tcc-staging" > counter:<value:1.58467339842e+09 >  has help "Start time of the process since unix epoch." but should have "Start time of the process since unix epoch in seconds."
```

Signed-off-by: Liam White <liam@tetrate.io>