### PR TITLE
handle multiple metrics with the same signature

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/prometheus.go
+++ b/prometheus.go
@@ -46,6 +46,7 @@ type Exporter struct {
 type Options struct {
 	Namespace   string
 	OnError     func(err error)
+	ErrorLogger promhttp.Logger
 	ConstLabels prometheus.Labels // ConstLabels will be set as labels on all views.
 	Registry    *prometheus.Registry
 }
@@ -60,7 +61,10 @@ func New(o Options) (*Exporter, error) {
 		options:   o,
 		gatherer:  o.Registry,
 		collector: collector,
-		handler:   promhttp.HandlerFor(o.Registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}),
+		handler: promhttp.HandlerFor(o.Registry, promhttp.HandlerOpts{
+			ErrorHandling: promhttp.ContinueOnError,
+			ErrorLog:      o.ErrorLogger,
+		}),
 	}
 	return exp, nil
 }

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -415,7 +415,9 @@ func TestMetricsEndpointOutput(t *testing.T) {
 	// Now record some metrics.
 	metrics := makeMetrics()
 	for _, metric := range metrics {
-		exp.ExportMetric(context.Background(), nil, nil, metric)
+		if err := exp.ExportMetric(context.Background(), nil, nil, metric); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	var i int

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -336,6 +336,37 @@ func makeMetrics() []*metricspb.Metric {
 				},
 			},
 		},
+		// Same metric signature, different label values
+		{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        "this/one/there(where)",
+				Description: "Extra ones",
+				Unit:        "1",
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "os", Description: "Operating system"},
+					{Key: "arch", Description: "Architecture"},
+					{Key: "my.org/department", Description: "The department that owns this server"},
+				},
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					StartTimestamp: startTimestamp,
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "linux"},
+						{Value: "x86"},
+						{Value: "Platform"},
+					},
+					Points: []*metricspb.Point{
+						{
+							Timestamp: endTimestamp,
+							Value: &metricspb.Point_DoubleValue{
+								DoubleValue: 12.3,
+							},
+						},
+					},
+				},
+			},
+		},
 		// Unlimited key length.
 		{
 			MetricDescriptor: &metricspb.MetricDescriptor{
@@ -427,6 +458,7 @@ a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_a_
 # HELP this_one_there_where_ Extra ones
 # TYPE this_one_there_where_ gauge
 this_one_there_where_{arch="386",my_org_department="Ops",os="darwin"} 49.5
+this_one_there_where_{arch="x86",my_org_department="Platform",os="linux"} 12.3
 this_one_there_where_{arch="x86",my_org_department="Storage",os="windows"} 99
 # HELP with_metric_descriptor This is a test
 # TYPE with_metric_descriptor histogram


### PR DESCRIPTION
OpenTelemetry Collector splits the same metric across multiple calls to ExportMetric when it scrapes the same metric from multiple targets. This manifests in our setup with all grpc metrics clobbering one another.

See https://github.com/open-telemetry/opentelemetry-collector/issues/1076 for background.

Signed-off-by: Liam White <liam@tetrate.io>